### PR TITLE
Circle CI でのテストが実行されるようにした

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,9 +56,9 @@ jobs:
             . venv/bin/activate
             codecov
 
-  python35:
+  python38:
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.8
       - image: rabbitmq:3.7
       - image: memcached:1.5
       - image: docker.elastic.co/elasticsearch/elasticsearch:6.2.3
@@ -73,14 +73,14 @@ jobs:
           MYSQL_DATABASE: airone
         command: [--character-set-server=utf8, --collation-server=utf8_general_ci, --default-storage-engine=innodb]
     environment:
-      TOXENV: "py35"
+      TOXENV: "py38"
     steps:
       - checkout
       - run:
           name: Wait for ElasticSearch
           command: dockerize -wait tcp://127.0.0.1:9200 -timeout 120s
       - restore_cache:
-          key: py35-{{ checksum "requirements.txt" }}-{{ checksum "tox.ini" }}
+          key: py38-{{ checksum "requirements.txt" }}-{{ checksum "tox.ini" }}
       - run:
           name: Install tox tox-pyenv coverage
           command: |
@@ -102,14 +102,14 @@ jobs:
             . venv/bin/activate
             tox
       - save_cache:
-          key: py35-{{ checksum "requirements.txt" }}-{{ checksum "tox.ini" }}
+          key: py38-{{ checksum "requirements.txt" }}-{{ checksum "tox.ini" }}
           paths:
             - venv
-            - .tox/py35
+            - .tox/py38
 
   pep8:
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.8
     environment:
       TOXENV: "pep8"
     steps:
@@ -145,7 +145,7 @@ workflows:
   build_and_test:
     jobs:
       - python36
-      - python35
+      - python38
       - pep8
       - build_gh_page:
           filters:

--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,7 @@
 max-line-length = 100
 exclude =
     ./venv,
+    ./.venv,
     ./.tox,
     ./*/migrations,
     .manage.py

--- a/airone/lib/http.py
+++ b/airone/lib/http.py
@@ -29,7 +29,7 @@ def http_get(func):
         if request.method != 'GET':
             return HttpResponse('Invalid HTTP method is specified', status=400)
 
-        if not request.user.is_authenticated():
+        if not request.user.is_authenticated:
             return HttpResponseSeeOther('/dashboard/login?next=%s' % request.path)
 
         return func(*args, **kwargs)
@@ -64,7 +64,7 @@ def check_superuser(func):
     def wrapper(*args, **kwargs):
         request = args[0]
 
-        if not request.user.is_authenticated():
+        if not request.user.is_authenticated:
             return HttpResponseSeeOther('/dashboard/login')
 
         if not request.user.is_superuser:
@@ -82,7 +82,7 @@ def http_post(validator=[]):
             if request.method != 'POST':
                 return HttpResponse('Invalid HTTP method is specified', status=400)
 
-            if not request.user.is_authenticated():
+            if not request.user.is_authenticated:
                 return HttpResponse('You have to login to execute this operation', status=401)
 
             try:
@@ -106,7 +106,7 @@ def http_post_form(validator=[]):
             if request.method != 'POST':
                 return HttpResponse('Invalid HTTP method is specified', status=400)
 
-            if not request.user.is_authenticated():
+            if not request.user.is_authenticated:
                 return HttpResponse('You have to login to execute this operation', status=401)
 
             recv_data = {}

--- a/airone/urls.py
+++ b/airone/urls.py
@@ -22,6 +22,6 @@ urlpatterns = [
 
 for extension in settings.AIRONE['EXTENSIONS']:
     urlpatterns.append(url(r'^extension/%s' % extension,
-                           include('%s.urls' % extension, extension)))
+                           include(('%s.urls' % extension, extension))))
 
 urlpatterns += staticfiles_urlpatterns()

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -1,5 +1,4 @@
 from django.conf.urls import url
-from django.contrib.auth import views as auth_views
 
 from . import views
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -30,7 +30,7 @@ Logger = logging.getLogger(__name__)
 @airone_profile
 def index(request):
     context = {}
-    if request.user.is_authenticated() and User.objects.filter(id=request.user.id).exists():
+    if request.user.is_authenticated and User.objects.filter(id=request.user.id).exists():
         history = []
         # Sort by newest attribute update date (id is auto increment)
         for attr_value in AttributeValue.objects.order_by(

--- a/manage.py
+++ b/manage.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
-import pymysql
 
-pymysql.install_as_MySQLdb()
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "airone.settings")

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,12 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py3{5,6}, pep8
+envlist = py3{6,8}, pep8
 skipsdist = TRUE
 
 [testenv:py36]
 # settings for selecting backend-db to use in test
-passenv = AIRONE_BACKEND_DB
+passenv = AIRONE_BACKEND_DB CODECOV_*
 commands =
   rm -f db.sqlite3
   pip install -r requirements-dev.txt
@@ -20,7 +20,7 @@ commands =
   coverage report
 whitelist_externals = rm
 
-[testenv:py35]
+[testenv:py38]
 # settings for selecting backend-db to use in test
 passenv = AIRONE_BACKEND_DB CODECOV_*
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ commands =
   pip install -r requirements-dev.txt
   python manage.py makemigrations
   python manage.py migrate
+  python manage.py collectstatic
   coverage run manage.py test
   coverage run manage.py test tools.tests
   coverage report
@@ -28,6 +29,7 @@ commands =
   pip install -r requirements-dev.txt
   python manage.py makemigrations
   python manage.py migrate
+  python manage.py collectstatic
   python manage.py test
   python manage.py test tools.tests
 whitelist_externals = rm

--- a/user/views.py
+++ b/user/views.py
@@ -17,7 +17,7 @@ from .models import User
 
 @http_get
 def index(request):
-    if not request.user.is_authenticated():
+    if not request.user.is_authenticated:
         return HttpResponseSeeOther('/dashboard/login')
 
     user = User.objects.get(id=request.user.id)


### PR DESCRIPTION
flake8 のエラー

```
$ flake8 .
./dashboard/urls.py:2:1: F401 'django.contrib.auth.views as auth_views' imported but unused
```

上記を除去しました。

ほか tox の環境を `py35`, `py36` の組み合わせから `py36`, `py38` の組み合わせにしました。

virtualenv として `.venv` も使うことを想定しました。

ref. https://docs.python.org/ja/3/library/venv.html

> よく使われるターゲットディレクトリの名前は `.venv` です